### PR TITLE
Install PhantomJS 1.9.8 instead of 2.0

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,7 +7,7 @@ brew 'redis'
 brew 'postgresql92', args: ['with-perl']
 brew 'elasticsearch'
 brew 'homebrew/boneyard/wkhtmltopdf'
-brew 'phantomjs'
+brew 'phantomjs198'
 brew 'php54', args: ['with-pgsql', 'with-fpm']
 brew 'cassandra'
 brew 'varnish'


### PR DESCRIPTION
Currently there a [bunch](https://github.com/teampoltergeist/poltergeist/issues/574) [of](https://github.com/ariya/phantomjs/issues/12506) [issues](https://github.com/travis-ci/travis-ci/issues/3225) when running Poltergeist against PhantomJS 2.0. Within the [alpaca](https://github.com/FundingCircle/alpaca), tests are failing with:

```
    Cliver::Dependency::VersionMismatch:
       Could not find an executable 'phantomjs' that matched the requirements '~> 1.8', '>= 1.8.1'. Found versions were {"/usr/local/bin/phantomjs"=>"2.0.0"}.
```

Maybe this pull request will become irrelevant soon, but currently it's an issue when running the tests.