### PR TITLE
Install brewdler via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 * Homebrew (http://brew.sh)
-* Brewdler (`gem install brewdler`)
+* Brewdler (`brew tap Homebrew/brewdler`)
 * XCode command line tools
 
 ### OS X

--- a/bin/install
+++ b/bin/install
@@ -6,15 +6,8 @@ if [[ -z $(which brew) ]]; then
   exit 1
 fi
 
-gem which brewdler 1>/dev/null 2>&1
-if [[ $? -ne 0 ]]; then
-  echo 'Unable to find brewdler gem, installing it'
-  gem install brewdler
-fi
-
 brew update
 brew upgrade
-
-brewdle install
-
+brew tap Homebrew/brewdler
+brew brewdle
 brew cleanup


### PR DESCRIPTION
Installing `brewdler` as a gem is deprecated:

```
puts "Installing brewdler from rubygems has been deprecated, instead install with:"
puts "\n  brew tap Homebrew/brewdler"
puts "\nFor more info see: https://github.com/Homebrew/homebrew-brewdler"
```