### PR TITLE
Use version-specific elasticsearch

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,7 +5,7 @@ tap 'homebrew/versions'
 brew 'qt'
 brew 'redis'
 brew 'postgresql92', args: ['with-perl']
-brew 'elasticsearch'
+brew 'elasticsearch090'
 brew 'homebrew/boneyard/wkhtmltopdf'
 brew 'phantomjs198'
 brew 'php54', args: ['with-pgsql', 'with-fpm']


### PR DESCRIPTION
The version used on CircleCI (and required for the codas specs to pass locally) is ~ 0.90