### PR TITLE
Lock cassandra to 2.0

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,7 +9,7 @@ brew 'elasticsearch090'
 brew 'homebrew/boneyard/wkhtmltopdf'
 brew 'phantomjs198'
 brew 'php54', args: ['with-pgsql', 'with-fpm']
-brew 'cassandra'
+brew 'homebrew/versions/cassandra20'
 brew 'varnish'
 brew 'memcached'
 brew 'node'


### PR DESCRIPTION
2.2 has schema changes in **system.schema_columnfamilies**, which is currently used to generate seeds:

    /Users/davidlantos/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/cql-rb-1e2b00571c76/lib/cql/client/synchronous_client.rb:54:
      in `execute': Undefined name key_aliases in selection clause (Cql::QueryError)
        from /Users/davidlantos/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/bundler/gems/virsandra-92431b101d14/lib/virsandra/connection.rb:30:in `execute'
        from /Users/davidlantos/Work/codas/lib/company_seeder/discover_documents.rb:18:in `read'
        from /Users/davidlantos/Work/codas/lib/company_seeder/discover_documents.rb:9:in `call'
        from /Users/davidlantos/Work/codas/lib/company_seeder/generate_seed.rb:13:in `initialize'

The query in question:

    select columnfamily_name, key_aliases, key_validator
      from schema_columnfamilies where keyspace_name='codas';