### PR TITLE
Fix the 'No such file or directory' error for cassandra_version_check.sh

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -8,7 +8,7 @@ if [[ -z $(which brew) ]]; then
   exit 1
 fi
 
-source cassandra_version_check.sh
+source "${BASH_SOURCE%/*}/cassandra_version_check.sh"
 
 brew update
 brew upgrade


### PR DESCRIPTION
New starters are all getting the error 

    bin/install: line 11: cassandra_version_check.sh: No such file or directory

With this change it should work in all cases.