### PR TITLE
Use FundingCircle tap for Elasticsearch v0.90

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,5 +1,6 @@
-tap 'homebrew/php'
+tap 'fundingcircle/elasticsearch'
 tap 'homebrew/dupes'
+tap 'homebrew/php'
 tap 'homebrew/versions'
 
 brew 'qt'


### PR DESCRIPTION
:information_desk_person: Use the [self-hosted tap for Elasticsearch v0.90](https://github.com/FundingCircle/homebrew-elasticsearch).

Closes #22 